### PR TITLE
Update Travis build script to dynamically determine build targets

### DIFF
--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,21 +1,11 @@
 #!/bin/bash
 
-targets=""
-targets+=" hdk/muc/base_powered"
-targets+=" hdk/muc/base_unpowered"
-targets+=" hdk/muc/battery"
-targets+=" hdk/muc/blinky"
-targets+=" hdk/muc/compute"
-targets+=" hdk/muc/display"
-targets+=" hdk/muc/factory"
-targets+=" hdk/muc/speaker"
-targets+=" hdk/muc/temperature"
+defconfig_list=$(find nuttx/configs/hdk -iname defconfig)
 
-targets+=" hdk/apbe/base"
+for cfg in $defconfig_list; do
+  configpath=$(dirname "$cfg")
+  mod=$(echo "$configpath" | sed -e "s:^nuttx/configs/::")
 
-echo targets: ${targets}
-
-for mod in $targets; do
   echo "============================================"
   echo "== " $mod
   echo "============================================"


### PR DESCRIPTION
Instead of hard-coding the build targets, the build script will
now find and build all hdk targets. This will allow build targets
to be added without needing to update the Travis build script.

Signed-off-by: Greg Meiste w30289@motorola.com
