### PR TITLE
Remove several unused-const-variable build errors

### DIFF
--- a/nuttx/arch/arm/src/tsb/dmac/tsb_dma_gdmac.c
+++ b/nuttx/arch/arm/src/tsb/dmac/tsb_dma_gdmac.c
@@ -483,9 +483,6 @@ static struct tsb_gdmac_drv_info {
 
 static struct gdmac_event gdmac_event_to_chan_map[GDMAC_NUMBER_OF_EVENTS];
 
-static const uint16_t skip_mem_load_and_store = (DMANOP | (DMANOP << 8));
-static const uint16_t do_mem_load_and_store = (DMALD | (DMAST << 8));
-
 static inline uint32_t gsmac_bit_to_pos(uint32_t value)
 {
     if (value == 0) {

--- a/nuttx/drivers/camera/camera_ext_mhb_imx219_pi.c
+++ b/nuttx/drivers/camera/camera_ext_mhb_imx219_pi.c
@@ -154,6 +154,7 @@ static const struct cam_i2c_reg_array res0_array[] = {
     { 0x015B, 0xDC, },
 };
 
+#if 0
 static const struct cam_i2c_reg_array res1_array[] = {
     { 0x0103, 0x01, },
     { 0x0100, 0x00, },
@@ -296,12 +297,14 @@ static const struct cam_i2c_reg_array res2_array[] = {
     { 0x015A, 0x05, },
     { 0x015B, 0xDC, },
 };
+#endif
 
 static const struct cam_i2c_reg_setting frmival_res0_user_data = {
     .size = ARRAY_SIZE(res0_array),
     .regs = res0_array,
 };
 
+#if 0
 static const struct cam_i2c_reg_setting frmival_res1_user_data = {
     .size = ARRAY_SIZE(res1_array),
     .regs = res1_array,
@@ -311,6 +314,7 @@ static const struct cam_i2c_reg_setting frmival_res2_user_data = {
     .size = ARRAY_SIZE(res2_array),
     .regs = res2_array,
 };
+#endif
 
 static const struct camera_ext_frmival_node frmival_res0[] = {
     {
@@ -320,6 +324,7 @@ static const struct camera_ext_frmival_node frmival_res0[] = {
     },
 };
 
+#if 0
 static const struct camera_ext_frmival_node frmival_res1[] = {
     {
         .numerator = 1,
@@ -335,6 +340,7 @@ static const struct camera_ext_frmival_node frmival_res2[] = {
         .user_data = &frmival_res2_user_data,
     },
 };
+#endif
 
 // frame sizes for BGGR10
 static const struct camera_ext_frmsize_node _cam_frmsizes[] = {
@@ -593,4 +599,3 @@ struct device_driver imx219_pi_mhb_camera_driver = {
     .desc = "Raspberry Pi Camera",
     .ops  = &_mhb_camera_driver_ops,
 };
-

--- a/nuttx/libc/stdio/lib_dtoa.c
+++ b/nuttx/libc/stdio/lib_dtoa.c
@@ -808,12 +808,10 @@ static const double tens[] =
 
 #ifdef IEEE_Arith
 static const double bigtens[] = { 1e16, 1e32, 1e64, 1e128, 1e256 };
-static const double tinytens[] = { 1e-16, 1e-32, 1e-64, 1e-128, 1e-256 };
 
 #  define n_bigtens 5
 #else
 static const double bigtens[] = { 1e16, 1e32 };
-static const double tinytens[] = { 1e-16, 1e-32 };
 
 #  define n_bigtens 2
 #endif

--- a/nuttx/sched/pthread/pthread_create.c
+++ b/nuttx/sched/pthread/pthread_create.c
@@ -80,9 +80,11 @@ const pthread_attr_t g_default_pthread_attr = PTHREAD_ATTR_INITIALIZER;
  * Private Variables
  ****************************************************************************/
 
+#if CONFIG_TASK_NAME_SIZE > 0
 /* This is the name for name-less pthreads */
 
 static const char g_pthreadname[] = "<pthread>";
+#endif
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
The toolchain on Travis must have been updated to be more strict, because I was seeing several unused-const-variable errors not seen before. With this stack of patches, I'm able to build on Travis again.

For the camera file, I used #if 0 to remove the variables since the code that used the variables was removed by a #if 0 and I wanted to be consistent in that file.