### PR TITLE
arm: stm32_gpio: Fix gpio interrupt check

### DIFF
--- a/nuttx/arch/arm/src/stm32/stm32_gpio.c
+++ b/nuttx/arch/arm/src/stm32/stm32_gpio.c
@@ -881,12 +881,14 @@ int stm32_getconfiggpio(uint32_t *cfgset)
   else
     {
       uint32_t regaddr;
+      uint32_t mask;
       int shift;
 
       regaddr = STM32_SYSCFG_EXTICR(pin);
       regval  = getreg32(regaddr);
       shift   = SYSCFG_EXTICR_EXTI_SHIFT(pin);
-      regval  = (regval & SYSCFG_EXTICR_PORT_MASK) >> shift;
+      mask    = SYSCFG_EXTICR_EXTI_MASK(pin);
+      regval  = (regval & mask) >> shift;
       if (regval == port)
         {
           *cfgset |= GPIO_EXTI;


### PR DESCRIPTION
SYSCFG_EXTICR_PORT_MASK is a pre-shifted mask and will not work
correctly on the high order bits.  This will case get_configgpio
to return incorrect values on some gpios.  The macro
SYSCFG_EXTICR_EXTI_MASK() shifts the mask into the correct location
for the pin.  Replace the SYSCFG_EXTICR_PORT_MASK, with
SYSCFG_EXTICR_EXTI_MASK(pin) when testing the mask in get_configgpio.

Signed-off-by: Jim Wylder <jwylder@motorola.com>