### PR TITLE
ADC device init and ADC NSH tool

### DIFF
--- a/apps/system/Kconfig
+++ b/apps/system/Kconfig
@@ -3,6 +3,10 @@
 # see misc/tools/kconfig-language.txt.
 #
 
+menu "ADC tool"
+source "$APPSDIR/system/adc/Kconfig"
+endmenu
+
 menu "Custom Free Memory Command"
 source "$APPSDIR/system/free/Kconfig"
 endmenu

--- a/apps/system/Make.defs
+++ b/apps/system/Make.defs
@@ -34,6 +34,10 @@
 #
 ############################################################################
 
+ifeq ($(CONFIG_SYSTEM_ADCTOOL),y)
+CONFIGURED_APPS += system/adc
+endif
+
 ifeq ($(CONFIG_SYSTEM_CDCACM),y)
 CONFIGURED_APPS += system/cdcacm
 endif

--- a/apps/system/Makefile
+++ b/apps/system/Makefile
@@ -37,7 +37,7 @@
 
 # Sub-directories containing system task
 
-SUBDIRS  = cdcacm cle composite flash_eraseall free i2c hex2bin inifile
+SUBDIRS  = adc cdcacm cle composite flash_eraseall free i2c hex2bin inifile
 SUBDIRS += install mdio nxplayer poweroff ramtest ramtron readline sdcard
 SUBDIRS += stackmonitor sudoku sysinfo usbmonitor usbmsc vi zmodem
 

--- a/apps/system/adc/Kconfig
+++ b/apps/system/adc/Kconfig
@@ -1,0 +1,14 @@
+config SYSTEM_ADCTOOL
+	bool "ADC tool"
+	default n
+	depends on ADC
+	---help---
+		Enable support for the ADC tool.
+
+if SYSTEM_ADCTOOL
+config ADCTOOL_APP_PROGNAME
+	string "Program name"
+	default "adc"
+	---help---
+		Name of the app.
+endif

--- a/apps/system/adc/Makefile
+++ b/apps/system/adc/Makefile
@@ -1,0 +1,130 @@
+#
+# Copyright (c) 2017 Motorola Mobility, LLC.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# ADC tool
+APPNAME = adc
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = 2048
+
+ASRCS =
+CSRCS =
+MAINSRC = adc_main.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_ADCTOOL_APP_PROGNAME ?= $(APPNAME)$(EXEEXT)
+PROGNAME = $(CONFIG_ADCTOOL_APP_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+VPATH =
+
+# Build targets
+
+all: .built
+	@true
+
+.PHONY: context .depend depend clean distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	$(Q) touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_NSH_BUILTIN_APPS),y)
+$(BUILTIN_REGISTRY)$(DELIM)$(APPNAME)_main.bdat: $(DEPCONFIG) Makefile
+	$(call REGISTER,$(APPNAME),$(PRIORITY),$(STACKSIZE),$(APPNAME)_main)
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(APPNAME)_main.bdat
+else
+context:
+endif
+	@true
+
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+

--- a/apps/system/adc/adc_main.c
+++ b/apps/system/adc/adc_main.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2017 Motorola Mobility, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/ioctl.h>
+
+#include <nuttx/analog/adc.h>
+#include <nuttx/arch.h>
+#include <nuttx/util.h>
+
+typedef int (*COMMAND_FP)(int argc, const char *argv[]);
+
+struct command {
+    const char *str;
+    const COMMAND_FP fp;
+};
+
+static const struct command *find_cmd(const char *str,
+                                      const struct command *cmds,
+                                      size_t num_cmds)
+{
+    while (num_cmds--) {
+        if (!strcmp(cmds->str, str)) {
+            return cmds;
+        }
+        cmds++;
+    }
+
+    return NULL;
+}
+
+static void print_cmds(const char *header,
+                       const struct command *cmds,
+                       size_t num_cmds,
+                       const char *trailer)
+{
+    if (header) {
+        printf(header);
+    }
+
+    while (num_cmds--) {
+        printf(" %s %c", cmds->str, num_cmds > 0 ? '|' : ' ');
+        cmds++;
+    }
+
+    if (trailer) {
+        printf(trailer);
+    }
+}
+
+static int execute_cmd(int argc,
+                       const char *argv[],
+                       const struct command *cmds,
+                       size_t num_cmds)
+{
+    const struct command *cmd;
+    int ret = OK;
+
+    cmd = find_cmd(argv[0], cmds, num_cmds);
+    if (!cmd) {
+        printf("ERROR: Unknown command: %s\n", argv[0]);
+        print_cmds("", cmds, num_cmds, "\n");
+        return -EINVAL;
+    }
+
+    ret = cmd->fp(argc-1, argv+1);
+    return ret;
+}
+
+static int _adc_get(const char *devpath, struct adc_msg_s *adc_msg, size_t num_msgs)
+{
+    int fd;
+    size_t i;
+    size_t retries = 0;
+    int ret;
+
+    fd = open(devpath, O_RDONLY|O_NONBLOCK);
+    if (fd < 0) {
+        fprintf(stderr, "ERROR: open failed: %d\n", errno);
+        return -ENODEV;
+    }
+
+    /* Start the ADC conversion. */
+    ret = ioctl(fd, ANIOC_TRIGGER, 0);
+    if (ret < 0) {
+        fprintf(stderr, "ERROR: ioctl failed: %d\n", errno);
+        close(fd);
+        return -EIO;
+    }
+
+    /* HACK: Give the ADC some time to receive all the values.
+     * If we call read() too soon, it will mask the ADC interrupts and we will
+     * lose interrupts. */
+    up_udelay(50);
+
+    /* The ADC device only allows a single adc_msg read at a time. */
+    i = 0;
+    while (i < num_msgs && retries < 3) {
+
+        ret = read(fd, &adc_msg[i], sizeof(*adc_msg));
+        vdbg("read: ret=%d, errno=%d\n", ret, errno);
+        if (ret != sizeof(*adc_msg)) {
+            if (errno == EAGAIN) {
+                retries++;
+                continue;
+            }
+
+            vdbg("read failed: ret=%d, errno=%d\n", ret, errno);
+            ret = errno;
+            break;
+        } else {
+            vdbg("chan=%d, data=%d\n", adc_msg[i].am_channel, adc_msg[i].am_data);
+            i++;
+            retries = 0;
+            ret = OK;
+        }
+    }
+
+    if (fd >= 0) {
+        close(fd);
+    }
+
+    return i ? i : ret;
+}
+
+
+static int adc_get(int argc, const char *argv[])
+{
+    int interface;
+    int count;
+    int delay;
+    char devpath[16];
+    struct adc_msg_s adc_msgs[16];
+    size_t c;
+    size_t i;
+    int ret = OK;
+
+    interface = (argc > 0 ? atoi(argv[0]) : 0);
+    count = (argc > 1 ? atoi(argv[1]) : 1);
+    delay = (argc > 2 ? atoi(argv[2]) : 1000);
+
+    snprintf(devpath, ARRAY_SIZE(devpath), "/dev/adc%d", interface);
+    vdbg("get: interface=%d, devpath=%s\n", interface, devpath);
+
+    for (c = 0; c < count; c++) {
+        ret = _adc_get(devpath, adc_msgs, ARRAY_SIZE(adc_msgs));
+        vdbg("ret=%d\n", ret);
+
+        /* Success, print values. */
+        if (ret > 0) {
+            for (i = 0; i < ret; i++) {
+                printf("channel=%d, value=%d (0x%08x)\n",
+                  adc_msgs[i].am_channel, adc_msgs[i].am_data, adc_msgs[i].am_data);
+            }
+        }
+
+        usleep(delay*1000);
+    }
+
+    return ret;
+}
+
+static const struct command COMMANDS[] = { \
+    {"g", adc_get},
+    {"get", adc_get},
+};
+
+int adc_main(int argc, const char *argv[])
+{
+    int ret;
+
+    /* Eat the argument that got us here. */
+    argc -= 1;
+    argv += 1;
+
+    if (argc == 0) {
+        print_cmds("usage: " CONFIG_ADCTOOL_APP_PROGNAME,
+                   COMMANDS, ARRAY_SIZE(COMMANDS), "\n");
+        ret = -EAGAIN;
+    } else {
+        ret = execute_cmd(argc, argv, COMMANDS, ARRAY_SIZE(COMMANDS));
+    }
+
+    return ret;
+}

--- a/nuttx/arch/arm/src/stm32/Kconfig
+++ b/nuttx/arch/arm/src/stm32/Kconfig
@@ -1223,6 +1223,237 @@ config STM32_ADC4
 	select STM32_ADC
 	depends on STM32_HAVE_ADC4
 
+config STM32_ADC_INIT
+	bool "ADC Device Initialization"
+	default n
+	depends on ADC
+	---help---
+		Create a /dev/adcX for each ADC device.
+
+if STM32_ADC_INIT
+if STM32_ADC1
+menu "ADC1 Device Initialization"
+
+config STM32_ADC1_CHAN0_INIT
+	bool "ADC1 Channel 0"
+	default n
+config STM32_ADC1_CHAN1_INIT
+	bool "ADC1 Channel 1"
+	default n
+config STM32_ADC1_CHAN2_INIT
+	bool "ADC1 Channel 2"
+	default n
+config STM32_ADC1_CHAN3_INIT
+	bool "ADC1 Channel 3"
+	default n
+config STM32_ADC1_CHAN4_INIT
+	bool "ADC1 Channel 4"
+	default n
+config STM32_ADC1_CHAN5_INIT
+	bool "ADC1 Channel 5"
+	default n
+config STM32_ADC1_CHAN6_INIT
+	bool "ADC1 Channel 6"
+	default n
+config STM32_ADC1_CHAN7_INIT
+	bool "ADC1 Channel 7"
+	default n
+config STM32_ADC1_CHAN8_INIT
+	bool "ADC1 Channel 8"
+	default n
+config STM32_ADC1_CHAN9_INIT
+	bool "ADC1 Channel 9"
+	default n
+config STM32_ADC1_CHAN10_INIT
+	bool "ADC1 Channel 10"
+	default n
+config STM32_ADC1_CHAN11_INIT
+	bool "ADC1 Channel 11"
+	default n
+config STM32_ADC1_CHAN12_INIT
+	bool "ADC1 Channel 12"
+	default n
+config STM32_ADC1_CHAN13_INIT
+	bool "ADC1 Channel 13"
+	default n
+config STM32_ADC1_CHAN14_INIT
+	bool "ADC1 Channel 14"
+	default n
+config STM32_ADC1_CHAN15_INIT
+	bool "ADC1 Channel 15"
+	default n
+endmenu
+endif
+endif
+
+if STM32_ADC_INIT
+if STM32_ADC2
+menu "ADC3 Device Initialization"
+
+config STM32_ADC2_CHAN0_INIT
+	bool "ADC2 Channel 0"
+	default n
+config STM32_ADC2_CHAN1_INIT
+	bool "ADC2 Channel 1"
+	default n
+config STM32_ADC2_CHAN2_INIT
+	bool "ADC2 Channel 2"
+	default n
+config STM32_ADC2_CHAN3_INIT
+	bool "ADC2 Channel 3"
+	default n
+config STM32_ADC2_CHAN4_INIT
+	bool "ADC2 Channel 4"
+	default n
+config STM32_ADC2_CHAN5_INIT
+	bool "ADC2 Channel 5"
+	default n
+config STM32_ADC2_CHAN6_INIT
+	bool "ADC2 Channel 6"
+	default n
+config STM32_ADC2_CHAN7_INIT
+	bool "ADC2 Channel 7"
+	default n
+config STM32_ADC2_CHAN8_INIT
+	bool "ADC2 Channel 8"
+	default n
+config STM32_ADC2_CHAN9_INIT
+	bool "ADC2 Channel 9"
+	default n
+config STM32_ADC2_CHAN10_INIT
+	bool "ADC2 Channel 10"
+	default n
+config STM32_ADC2_CHAN11_INIT
+	bool "ADC2 Channel 11"
+	default n
+config STM32_ADC2_CHAN12_INIT
+	bool "ADC2 Channel 12"
+	default n
+config STM32_ADC2_CHAN13_INIT
+	bool "ADC2 Channel 13"
+	default n
+config STM32_ADC2_CHAN14_INIT
+	bool "ADC2 Channel 14"
+	default n
+config STM32_ADC2_CHAN15_INIT
+	bool "ADC2 Channel 15"
+	default n
+endmenu
+endif
+endif
+
+if STM32_ADC_INIT
+if STM32_ADC3
+menu "ADC1 Device Initialization"
+
+config STM32_ADC3_CHAN0_INIT
+	bool "ADC3 Channel 0"
+	default n
+config STM32_ADC3_CHAN1_INIT
+	bool "ADC3 Channel 1"
+	default n
+config STM32_ADC3_CHAN2_INIT
+	bool "ADC3 Channel 2"
+	default n
+config STM32_ADC3_CHAN3_INIT
+	bool "ADC3 Channel 3"
+	default n
+config STM32_ADC3_CHAN4_INIT
+	bool "ADC3 Channel 4"
+	default n
+config STM32_ADC3_CHAN5_INIT
+	bool "ADC3 Channel 5"
+	default n
+config STM32_ADC3_CHAN6_INIT
+	bool "ADC3 Channel 6"
+	default n
+config STM32_ADC3_CHAN7_INIT
+	bool "ADC3 Channel 7"
+	default n
+config STM32_ADC3_CHAN8_INIT
+	bool "ADC3 Channel 8"
+	default n
+config STM32_ADC3_CHAN9_INIT
+	bool "ADC3 Channel 9"
+	default n
+config STM32_ADC3_CHAN10_INIT
+	bool "ADC3 Channel 10"
+	default n
+config STM32_ADC3_CHAN11_INIT
+	bool "ADC3 Channel 11"
+	default n
+config STM32_ADC3_CHAN12_INIT
+	bool "ADC3 Channel 12"
+	default n
+config STM32_ADC3_CHAN13_INIT
+	bool "ADC3 Channel 13"
+	default n
+config STM32_ADC3_CHAN14_INIT
+	bool "ADC3 Channel 14"
+	default n
+config STM32_ADC3_CHAN15_INIT
+	bool "ADC3 Channel 15"
+	default n
+endmenu
+endif
+endif
+
+if STM32_ADC_INIT
+if STM32_ADC4
+menu "ADC4 Device Initialization"
+
+config STM32_ADC4_CHAN0_INIT
+	bool "ADC4 Channel 0"
+	default n
+config STM32_ADC4_CHAN1_INIT
+	bool "ADC4 Channel 1"
+	default n
+config STM32_ADC4_CHAN2_INIT
+	bool "ADC4 Channel 2"
+	default n
+config STM32_ADC4_CHAN3_INIT
+	bool "ADC4 Channel 3"
+	default n
+config STM32_ADC4_CHAN4_INIT
+	bool "ADC4 Channel 4"
+	default n
+config STM32_ADC4_CHAN5_INIT
+	bool "ADC4 Channel 5"
+	default n
+config STM32_ADC4_CHAN6_INIT
+	bool "ADC4 Channel 6"
+	default n
+config STM32_ADC4_CHAN7_INIT
+	bool "ADC4 Channel 7"
+	default n
+config STM32_ADC4_CHAN8_INIT
+	bool "ADC4 Channel 8"
+	default n
+config STM32_ADC4_CHAN9_INIT
+	bool "ADC4 Channel 9"
+	default n
+config STM32_ADC4_CHAN10_INIT
+	bool "ADC4 Channel 10"
+	default n
+config STM32_ADC4_CHAN11_INIT
+	bool "ADC4 Channel 11"
+	default n
+config STM32_ADC4_CHAN12_INIT
+	bool "ADC4 Channel 12"
+	default n
+config STM32_ADC4_CHAN13_INIT
+	bool "ADC4 Channel 13"
+	default n
+config STM32_ADC4_CHAN14_INIT
+	bool "ADC4 Channel 14"
+	default n
+config STM32_ADC4_CHAN15_INIT
+	bool "ADC4 Channel 15"
+	default n
+endmenu
+endif
+endif
+
 config STM32_COMP
 	bool "COMP"
 	default n

--- a/nuttx/arch/arm/src/stm32/Make.defs
+++ b/nuttx/arch/arm/src/stm32/Make.defs
@@ -233,6 +233,9 @@ CHIP_CSRCS += stm32l4x3xx_adc.c
 else
 CHIP_CSRCS += stm32_adc.c
 endif
+ifeq ($(CONFIG_STM32_ADC_INIT),y)
+CHIP_CSRCS += stm32_adc_init.c
+endif
 endif
 
 ifeq ($(CONFIG_DAC),y)

--- a/nuttx/arch/arm/src/stm32/stm32_adc_init.c
+++ b/nuttx/arch/arm/src/stm32/stm32_adc_init.c
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2017 Motorola Mobility, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <debug.h>
+#include <unistd.h>
+
+#include <nuttx/util.h>
+
+#include "stm32_adc.h"
+
+/* ADC1 */
+#define ADC1_INTERFACE (1)
+#define ADC1_DEVPATH "/dev/adc0"
+
+static const uint32_t ADC1_PINS[]  = {
+#if CONFIG_STM32_ADC1_CHAN0_INIT
+    GPIO_ADC1_IN0,
+#endif
+#if CONFIG_STM32_ADC1_CHAN1_INIT
+    GPIO_ADC1_IN1,
+#endif
+#if CONFIG_STM32_ADC1_CHAN2_INIT
+    GPIO_ADC1_IN2,
+#endif
+#if CONFIG_STM32_ADC1_CHAN3_INIT
+    GPIO_ADC1_IN3,
+#endif
+#if CONFIG_STM32_ADC1_CHAN4_INIT
+    GPIO_ADC1_IN4,
+#endif
+#if CONFIG_STM32_ADC1_CHAN5_INIT
+    GPIO_ADC1_IN5,
+#endif
+#if CONFIG_STM32_ADC1_CHAN6_INIT
+    GPIO_ADC1_IN6,
+#endif
+#if CONFIG_STM32_ADC1_CHAN7_INIT
+    GPIO_ADC1_IN7,
+#endif
+#if CONFIG_STM32_ADC1_CHAN8_INIT
+    GPIO_ADC1_IN8,
+#endif
+#if CONFIG_STM32_ADC1_CHAN9_INIT
+    GPIO_ADC1_IN9,
+#endif
+#if CONFIG_STM32_ADC1_CHAN10_INIT
+    GPIO_ADC1_IN10,
+#endif
+#if CONFIG_STM32_ADC1_CHAN11_INIT
+    GPIO_ADC1_IN11,
+#endif
+#if CONFIG_STM32_ADC1_CHAN12_INIT
+    GPIO_ADC1_IN12,
+#endif
+#if CONFIG_STM32_ADC1_CHAN13_INIT
+    GPIO_ADC1_IN13,
+#endif
+#if CONFIG_STM32_ADC1_CHAN14_INIT
+    GPIO_ADC1_IN14,
+#endif
+#if CONFIG_STM32_ADC1_CHAN15_INIT
+    GPIO_ADC1_IN15,
+#endif
+};
+
+static const uint8_t ADC1_CHANNELS[] = {
+#if CONFIG_STM32_ADC1_CHAN0_INIT
+    0,
+#endif
+#if CONFIG_STM32_ADC1_CHAN1_INIT
+    1,
+#endif
+#if CONFIG_STM32_ADC1_CHAN2_INIT
+    2,
+#endif
+#if CONFIG_STM32_ADC1_CHAN3_INIT
+    3,
+#endif
+#if CONFIG_STM32_ADC1_CHAN4_INIT
+    4,
+#endif
+#if CONFIG_STM32_ADC1_CHAN5_INIT
+    5,
+#endif
+#if CONFIG_STM32_ADC1_CHAN6_INIT
+    6,
+#endif
+#if CONFIG_STM32_ADC1_CHAN7_INIT
+    7,
+#endif
+#if CONFIG_STM32_ADC1_CHAN8_INIT
+    8,
+#endif
+#if CONFIG_STM32_ADC1_CHAN9_INIT
+    9,
+#endif
+#if CONFIG_STM32_ADC1_CHAN10_INIT
+    10,
+#endif
+#if CONFIG_STM32_ADC1_CHAN11_INIT
+    11,
+#endif
+#if CONFIG_STM32_ADC1_CHAN12_INIT
+    12,
+#endif
+#if CONFIG_STM32_ADC1_CHAN13_INIT
+    13,
+#endif
+#if CONFIG_STM32_ADC1_CHAN14_INIT
+    14,
+#endif
+#if CONFIG_STM32_ADC1_CHAN15_INIT
+    15,
+#endif
+};
+
+/* ADC2 */
+#define ADC2_INTERFACE (2)
+#define ADC2_DEVPATH "/dev/adc1"
+
+static const uint8_t ADC2_CHANNELS[] = {
+#if CONFIG_STM32_ADC2_CHAN0_INIT
+    0,
+#endif
+#if CONFIG_STM32_ADC2_CHAN1_INIT
+    1,
+#endif
+#if CONFIG_STM32_ADC2_CHAN2_INIT
+    2,
+#endif
+#if CONFIG_STM32_ADC2_CHAN3_INIT
+    3,
+#endif
+#if CONFIG_STM32_ADC2_CHAN4_INIT
+    4,
+#endif
+#if CONFIG_STM32_ADC2_CHAN5_INIT
+    5,
+#endif
+#if CONFIG_STM32_ADC2_CHAN6_INIT
+    6,
+#endif
+#if CONFIG_STM32_ADC2_CHAN7_INIT
+    7,
+#endif
+#if CONFIG_STM32_ADC2_CHAN8_INIT
+    8,
+#endif
+#if CONFIG_STM32_ADC2_CHAN9_INIT
+    9,
+#endif
+#if CONFIG_STM32_ADC2_CHAN10_INIT
+    10,
+#endif
+#if CONFIG_STM32_ADC2_CHAN11_INIT
+    11,
+#endif
+#if CONFIG_STM32_ADC2_CHAN12_INIT
+    12,
+#endif
+#if CONFIG_STM32_ADC2_CHAN13_INIT
+    13,
+#endif
+#if CONFIG_STM32_ADC2_CHAN14_INIT
+    14,
+#endif
+#if CONFIG_STM32_ADC2_CHAN15_INIT
+    15,
+#endif
+};
+
+/* ADC3 */
+#define ADC3_INTERFACE (3)
+#define ADC3_DEVPATH "/dev/adc2"
+
+static const uint8_t ADC3_CHANNELS[] = {
+#if CONFIG_STM32_ADC3_CHAN0_INIT
+    0,
+#endif
+#if CONFIG_STM32_ADC3_CHAN1_INIT
+    1,
+#endif
+#if CONFIG_STM32_ADC3_CHAN2_INIT
+    2,
+#endif
+#if CONFIG_STM32_ADC3_CHAN3_INIT
+    3,
+#endif
+#if CONFIG_STM32_ADC3_CHAN4_INIT
+    4,
+#endif
+#if CONFIG_STM32_ADC3_CHAN5_INIT
+    5,
+#endif
+#if CONFIG_STM32_ADC3_CHAN6_INIT
+    6,
+#endif
+#if CONFIG_STM32_ADC3_CHAN7_INIT
+    7,
+#endif
+#if CONFIG_STM32_ADC3_CHAN8_INIT
+    8,
+#endif
+#if CONFIG_STM32_ADC3_CHAN9_INIT
+    9,
+#endif
+#if CONFIG_STM32_ADC3_CHAN10_INIT
+    10,
+#endif
+#if CONFIG_STM32_ADC3_CHAN11_INIT
+    11,
+#endif
+#if CONFIG_STM32_ADC3_CHAN12_INIT
+    12,
+#endif
+#if CONFIG_STM32_ADC3_CHAN13_INIT
+    13,
+#endif
+#if CONFIG_STM32_ADC3_CHAN14_INIT
+    14,
+#endif
+#if CONFIG_STM32_ADC3_CHAN15_INIT
+    15,
+#endif
+};
+
+/* ADC4 */
+#define ADC4_INTERFACE (4)
+#define ADC4_DEVPATH "/dev/adc3"
+
+static const uint8_t ADC4_CHANNELS[] = {
+#if CONFIG_STM32_ADC4_CHAN0_INIT
+    0,
+#endif
+#if CONFIG_STM32_ADC4_CHAN1_INIT
+    1,
+#endif
+#if CONFIG_STM32_ADC4_CHAN2_INIT
+    2,
+#endif
+#if CONFIG_STM32_ADC4_CHAN3_INIT
+    3,
+#endif
+#if CONFIG_STM32_ADC4_CHAN4_INIT
+    4,
+#endif
+#if CONFIG_STM32_ADC4_CHAN5_INIT
+    5,
+#endif
+#if CONFIG_STM32_ADC4_CHAN6_INIT
+    6,
+#endif
+#if CONFIG_STM32_ADC4_CHAN7_INIT
+    7,
+#endif
+#if CONFIG_STM32_ADC4_CHAN8_INIT
+    8,
+#endif
+#if CONFIG_STM32_ADC4_CHAN9_INIT
+    9,
+#endif
+#if CONFIG_STM32_ADC4_CHAN10_INIT
+    10,
+#endif
+#if CONFIG_STM32_ADC4_CHAN11_INIT
+    11,
+#endif
+#if CONFIG_STM32_ADC4_CHAN12_INIT
+    12,
+#endif
+#if CONFIG_STM32_ADC4_CHAN13_INIT
+    13,
+#endif
+#if CONFIG_STM32_ADC4_CHAN14_INIT
+    14,
+#endif
+#if CONFIG_STM32_ADC4_CHAN15_INIT
+    15,
+#endif
+};
+
+static int stm32_adc_init_pins(const uint32_t *pins, size_t count)
+{
+    size_t i;
+
+    /* Configure the pins as analog inputs for the selected channels */
+    for (i = 0; i < count; i++) {
+        stm32_configgpio(pins[i]);
+    }
+
+    return OK;
+}
+
+static int stm32_adc_init_channel(int interface,
+                                  const uint8_t *channels, size_t count)
+{
+    struct adc_dev_s *adc;
+    int ret;
+
+    /* Call stm32_adcinitialize() to get an instance of the ADC interface */
+    adc = stm32_adcinitialize(interface, channels, count);
+    if (!adc) {
+        dbg("ERROR: Failed to get ADC interface: errno=%d\n", errno);
+        return -ENODEV;
+    }
+
+    /* Register the ADC driver */
+    ret = adc_register(ADC1_DEVPATH, adc);
+    if (ret < 0)
+    {
+        dbg("ERROR: Failed to register ADC device: devpath=%s ret=%d\n",
+            ADC1_DEVPATH, ret);
+    }
+
+    return ret;
+}
+
+int stm32_adc_initialize(void)
+{
+#if CONFIG_STM32_ADC1
+    stm32_adc_init_pins(ADC1_PINS, ARRAY_SIZE(ADC1_PINS));
+    stm32_adc_init_channel(ADC1_INTERFACE, ADC1_CHANNELS, ARRAY_SIZE(ADC1_CHANNELS));
+#endif
+#if CONFIG_STM32_ADC2
+    stm32_adc_init_pins(ADC1_PINS, ARRAY_SIZE(ADC2_PINS));
+    stm32_adc_init_channel(ADC2_INTERFACE, ADC2_CHANNELS, ARRAY_SIZE(ADC2_CHANNELS));
+#endif
+#if CONFIG_STM32_ADC3
+    stm32_adc_init_pins(ADC3_PINS, ARRAY_SIZE(ADC3_PINS));
+    stm32_adc_init_channel(ADC3_INTERFACE, ADC3_CHANNELS, ARRAY_SIZE(ADC3_CHANNELS));
+#endif
+#if CONFIG_STM32_ADC4
+    stm32_adc_init_pins(ADC4_PINS, ARRAY_SIZE(ADC4_PINS));
+    stm32_adc_init_channel(ADC4_INTERFACE, ADC4_CHANNELS, ARRAY_SIZE(ADC4_CHANNELS));
+#endif
+
+    return OK;
+}

--- a/nuttx/arch/arm/src/stm32/stm32_adc_init.h
+++ b/nuttx/arch/arm/src/stm32/stm32_adc_init.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * arch/arm/src/stm32/stm32_exti_comp.c
+ *
+ * Copyright (c) 2016 Motorola Mobility, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32_STM32_ADC_INIT_H
+#define __ARCH_ARM_SRC_STM32_STM32_ADC_INIT_H
+
+/************************************************************************************
+ * Public Function Prototypes
+ ************************************************************************************/
+
+#ifndef __ASSEMBLY__
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: stm32_adc_initialize
+ *
+ * Description:
+ *   Create a device for each configured ADC channel.
+ *
+ * Returned Value:
+ *   0 on succes, errno on failure
+ *
+ ****************************************************************************/
+
+EXTERN int stm32_adc_initialize(void);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+#endif /* __ASSEMBLY__ */
+
+#endif /* __ARCH_ARM_SRC_STM32_STM32_ADC_INIT_H */

--- a/nuttx/configs/hdk/muc/src/stm32_boot.c
+++ b/nuttx/configs/hdk/muc/src/stm32_boot.c
@@ -76,6 +76,7 @@
 
 #include "up_arch.h"
 #include "hdk.h"
+#include "stm32_adc_init.h"
 
 #include <nuttx/gpio/stm32_gpio_chip.h>
 
@@ -954,6 +955,10 @@ void board_initialize(void)
 
 #ifdef CONFIG_STM32_SPI
   stm32_spiinitialize();
+#endif
+
+#if CONFIG_STM32_ADC_INIT
+  stm32_adc_initialize();
 #endif
 
 #ifdef CONFIG_MODS_DIET


### PR DESCRIPTION
This patch creates ADC devices automatically using kconfig so drivers don't need to implement the boilerplate themselves. The downside is that it adds a lot of options to menuconfig. I tried to minimize it as best as I can. Would like feedback if there is a better way to do this.