### PR TITLE
apps: system: i2c: Automatically select I2C_TRANSFER

### DIFF
--- a/apps/system/i2c/Kconfig
+++ b/apps/system/i2c/Kconfig
@@ -8,6 +8,7 @@ config SYSTEM_I2CTOOL
 	bool "I2C tool"
 	default n
 	depends on I2C
+	select I2C_TRANSFER
 	---help---
 		Enable support for the I2C tool.
 


### PR DESCRIPTION
i2ctool requires I2C_TRANSFER to compile. Automatically select it.

Signed-off-by: Mike Corrigan <corrigan@motorola.com>