### PR TITLE
switch-ptp: disable charging with all_paths_open

### DIFF
--- a/nuttx/drivers/greybus/mods/switch-ptp-chg.c
+++ b/nuttx/drivers/greybus/mods/switch-ptp-chg.c
@@ -267,7 +267,9 @@ static int switch_ptp_chg_all_paths_open(struct device *dev)
     int retval = 0;
     struct switch_ptp_chg_info *info = device_get_private(dev);
 
-    dbg("\n");
+#ifdef CONFIG_GREYBUS_MODS_PTP_DEVICE_HAS_BATTERY
+    retval = device_charger_off(info->chg_dev);
+#endif
     wireless_path(info, true);
     wired_path(info, true);
     base_path(info, true);


### PR DESCRIPTION
When transitioning from a charging state to detached,
if the mod was receiving charge from the phone, then
switch_ptp_chg_all_paths_open() will allow battery
voltage to appear on VBUS.  Call device_charger_off(),
to prevent that.

Signed-off-by: Jim Wylder <jwylder@motorola.com>