### PR TITLE
Add I2C-related resources

### DIFF
--- a/nuttx/include/nuttx/device.h
+++ b/nuttx/include/nuttx/device.h
@@ -40,6 +40,7 @@ enum device_resource_type {
     DEVICE_RESOURCE_TYPE_REGS,
     DEVICE_RESOURCE_TYPE_IRQ,
     DEVICE_RESOURCE_TYPE_GPIO,
+    DEVICE_RESOURCE_TYPE_I2C_ADDR,
 };
 
 struct device_resource {

--- a/nuttx/include/nuttx/device.h
+++ b/nuttx/include/nuttx/device.h
@@ -41,6 +41,7 @@ enum device_resource_type {
     DEVICE_RESOURCE_TYPE_IRQ,
     DEVICE_RESOURCE_TYPE_GPIO,
     DEVICE_RESOURCE_TYPE_I2C_ADDR,
+    DEVICE_RESOURCE_TYPE_I2C_BUS,
 };
 
 struct device_resource {


### PR DESCRIPTION
Add the ability to specify the I2C bus and address in the device resources file.

The first patch is a cherry-pick from projectara. The other is new.