### PR TITLE
distclean additional files

### DIFF
--- a/nuttx/Makefile.unix
+++ b/nuttx/Makefile.unix
@@ -595,6 +595,8 @@ endif
 	$(call DELFILE, setenv.bat)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
+	$(call DELFILE, .version)
+	$(call DELFILE, tftf.hdr)
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps/ directory is included with NuttX,

--- a/nuttx/Makefile.win
+++ b/nuttx/Makefile.win
@@ -536,6 +536,8 @@ endif
 	$(call DELFILE, setenv.bat)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
+	$(call DELFILE, tftf.hdr)
+	$(call DELFILE, .version)
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps\ directory is included with NuttX,


### PR DESCRIPTION
Remove .version and tftf.hdr when 'make distclean' is run.

Signed-off-by: Mike Corrigan <corrigan@motorola.com>