### PR TITLE
apps: mods: mhb_server: Fix gearbox firewall 'fix'

### DIFF
--- a/apps/mods/mhb_server/sm.c
+++ b/apps/mods/mhb_server/sm.c
@@ -184,7 +184,7 @@ static void unipro_evt_handler(enum unipro_event evt)
 
         break;
     case UNIPRO_EVT_PWRMODE:
-        {
+        if (g_svc.gearbox) {
             uint32_t pmi_val0 = 0;
             rc = unipro_attr_read(TSB_DME_POWERMODEIND, &pmi_val0, 0, 0);
             llvdbg("rc=%d, pmi0=%x\n", rc, pmi_val0);
@@ -200,9 +200,7 @@ static void unipro_evt_handler(enum unipro_event evt)
                 llvdbg("Powermode change failed\n");
                 err = -1;
             }
-        }
 
-        if (g_svc.gearbox) {
             svc_send_event(SVC_EVENT_GEAR_SHIFT_DONE,
                 (void *)(unsigned int)err,
                 (void *)(unsigned int)0,


### PR DESCRIPTION
The previous gearbox firewall patch broke gear changes by allowing
the APBA to read the gear change status before the APBE. Revert the
invalid portion of the firewall.

Signed-off-by: Mike Corrigan <corrigan@motorola.com>