### PR TITLE
build: Add support to set major version number

### DIFF
--- a/nuttx/Makefile.unix
+++ b/nuttx/Makefile.unix
@@ -276,11 +276,13 @@ endif
 tools/mkversion$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)"  mkversion$(HOSTEXEEXT)
 
-ifneq (${BUILD_NUMBER},)
-  OVERRIDE_VERSION = 0.${BUILD_NUMBER}
-else
-  OVERRIDE_VERSION = 0.1
+ifeq (${BUILD_MAJOR_NUMBER},)
+  BUILD_MAJOR_NUMBER = 0
 endif
+ifeq (${BUILD_NUMBER},)
+  BUILD_NUMBER = 1
+endif
+OVERRIDE_VERSION = ${BUILD_MAJOR_NUMBER}.${BUILD_NUMBER}
 OVERRIDE_BUILD_NUM = ${shell git describe --always --dirty --match nothing 2>/dev/null}
 
 $(TOPDIR)/.version: FORCE


### PR DESCRIPTION
Add support to set the major version number (not just the minor
number) by setting the BUILD_MAJOR_NUMBER enviroment variable.

The minor version number will continue to be set by BUILD_VERSION
and the BUILD_NUMBER will continue to be automatically determined
by git describe.

For example running:
  BUILD_MAJOR_NUMBER=7 BUILD_NUMBER=13 make
will create a .version of:
  CONFIG_VERSION_STRING="7.13"
  CONFIG_VERSION_MAJOR=7
  CONFIG_VERSION_MINOR=13
  CONFIG_VERSION_BUILD="c843136-dirty"
and an equivalent include/nuttx/version.h.

Signed-off-by: Mike Corrigan <corrigan@motorola.com>