### PR TITLE
travis-build: Install pyelftools locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ before_install:
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get -qq update
   - sudo apt-get install -y git gperf flex bison libncurses5-dev gcc-arm-embedded python-pip
-  - sudo pip install pyelftools
 
 install:
   - git clone https://github.com/MotorolaMobilityLLC/manifesto /tmp/manifesto
   - git clone https://github.com/MotorolaMobilityLLC/bootrom-tools /tmp/bootrom-tools
   - export PATH=$PATH:/tmp/manifesto:/tmp/bootrom-tools
+  - pip install pyelftools
 
 script: ./travis_build.sh


### PR DESCRIPTION
Travis builds are failing because elftools.elf.elffile module
is not being found.

ImportError: No module named elftools.elf.elffile

Not clear why this worked previously and started failing recently
but it can be resolved in one of two ways:

1) Add the global installation path to PYTHONPATH variable, or
2) Install pyelftools as local user

Option two is implemented here.

Signed-off-by: Jim Wylder <jwylder@motorola.com>