### PR TITLE
greybus: battery: add set_ship_mode to battery protocol

### DIFF
--- a/nuttx/drivers/greybus/battery-gb.h
+++ b/nuttx/drivers/greybus/battery-gb.h
@@ -46,6 +46,7 @@
 #define GB_BATTERY_TYPE_CURRENT             0x08
 #define GB_BATTERY_TYPE_CAPACITY            0x09
 #define GB_BATTERY_TYPE_SHUTDOWN_TEMP       0x0a
+#define GB_BATTERY_TYPE_SHIP_MODE           0x0b    /* added in ver 00.02 */
 
 struct gb_battery_technology_response {
     __le32  technology;
@@ -81,6 +82,10 @@ struct gb_battery_totoal_capacity_response {
 
 struct gb_battery_shutdown_temperature_response {
     __le32  temperature;
+};
+
+struct gb_battery_set_ship_mode_request {
+    __u8 mode;
 };
 
 /* version request has no payload */

--- a/nuttx/drivers/greybus/battery.c
+++ b/nuttx/drivers/greybus/battery.c
@@ -42,7 +42,7 @@
 
 /* Version of the Greybus battery protocol we support */
 #define GB_BATTERY_VERSION_MAJOR    0x00
-#define GB_BATTERY_VERSION_MINOR    0x01
+#define GB_BATTERY_VERSION_MINOR    0x02
 
 /* Allocated in initial function for internal data store */
 static struct device *batt_dev = NULL;
@@ -287,6 +287,30 @@ static uint8_t gb_battery_shutdown_temp(struct gb_operation *operation)
 }
 
 /**
+* @brief Set battery to ship mode
+*
+* @param operation The pointer to structure of gb_operation.
+*
+* @return GB_OP_SUCCESS on success, error code on failure.
+*/
+static uint8_t gb_battery_set_ship_mode(struct gb_operation *operation)
+{
+    struct gb_battery_set_ship_mode_request *request;
+    int ret = 0;
+
+    if (gb_operation_get_request_payload_size(operation) < sizeof(*request)) {
+        gb_error("%s(): dropping short message\n", __func__);
+        return GB_OP_INVALID;
+    }
+
+    request = gb_operation_get_request_payload(operation);
+
+    ret = device_battery_set_ship_mode(batt_dev, request->mode);
+
+    return gb_errno_to_op_result(ret);
+}
+
+/**
  * @brief Greybus battery protocol initialize function
  *
  * @param cport CPort number
@@ -328,6 +352,7 @@ static struct gb_operation_handler gb_battery_handlers[] = {
     GB_HANDLER(GB_BATTERY_TYPE_CURRENT, gb_battery_current),
     GB_HANDLER(GB_BATTERY_TYPE_CAPACITY, gb_battery_capacity),
     GB_HANDLER(GB_BATTERY_TYPE_SHUTDOWN_TEMP, gb_battery_shutdown_temp),
+    GB_HANDLER(GB_BATTERY_TYPE_SHIP_MODE, gb_battery_set_ship_mode),
 };
 
 static struct gb_driver gb_battery_driver = {

--- a/nuttx/include/nuttx/device_battery.h
+++ b/nuttx/include/nuttx/device_battery.h
@@ -80,6 +80,9 @@ struct device_battery_type_ops {
 
     /** battery get_shutdown_temperature() function pointer */
     int (*get_shutdown_temp)(struct device *dev, int *shutdown_temp);
+
+    /** battery set_ship_mode() function pointer */
+    int (*set_ship_mode)(struct device *dev, uint8_t mode);
 };
 
 /**
@@ -255,6 +258,25 @@ static inline int device_battery_shutdown_temp(struct device *dev,
     if (DEVICE_DRIVER_GET_OPS(dev, battery)->get_shutdown_temp)
         return DEVICE_DRIVER_GET_OPS(dev, battery)->
                get_shutdown_temp(dev, temp);
+
+    return -ENOSYS;
+}
+
+/**
+ * @brief battery set ship mode
+ * @param dev pointer to structure of device data.
+ * @return 0 on success, negative errno on error.
+ */
+static inline int device_battery_set_ship_mode(struct device *dev, uint8_t mode)
+{
+    DEVICE_DRIVER_ASSERT_OPS(dev);
+
+    if (!device_is_open(dev))
+        return -ENODEV;
+
+    if (DEVICE_DRIVER_GET_OPS(dev, battery)->set_ship_mode)
+        return DEVICE_DRIVER_GET_OPS(dev, battery)->
+               set_ship_mode(dev, mode);
 
     return -ENOSYS;
 }


### PR DESCRIPTION
Used to prepare a mod with a battery for packaging and ship.
Definition of mode values are vendor specific.