### PR TITLE
greybus: battery: Add capability to read set_ship_mode

### DIFF
--- a/nuttx/drivers/greybus/battery-gb.h
+++ b/nuttx/drivers/greybus/battery-gb.h
@@ -84,8 +84,22 @@ struct gb_battery_shutdown_temperature_response {
     __le32  temperature;
 };
 
+enum gb_battery_ship_mode_ops {
+    GB_BATTERY_SET_SHIP_MODE_READ,       
+    GB_BATTERY_SET_SHIP_MODE_ENABLE,
+};
+      
 struct gb_battery_set_ship_mode_request {
     __u8 mode;
+};
+
+enum gb_battery_ship_mode_status {
+    GB_BATTERY_SET_SHIP_MODE_DISABLED,       
+    GB_BATTERY_SET_SHIP_MODE_ENABLED,
+};
+      
+struct gb_battery_set_ship_mode_response {
+    __u8 status;
 };
 
 /* version request has no payload */

--- a/nuttx/drivers/greybus/battery.c
+++ b/nuttx/drivers/greybus/battery.c
@@ -296,6 +296,8 @@ static uint8_t gb_battery_shutdown_temp(struct gb_operation *operation)
 static uint8_t gb_battery_set_ship_mode(struct gb_operation *operation)
 {
     struct gb_battery_set_ship_mode_request *request;
+    struct gb_battery_set_ship_mode_response *response;
+    uint8_t status = 0;
     int ret = 0;
 
     if (gb_operation_get_request_payload_size(operation) < sizeof(*request)) {
@@ -304,8 +306,16 @@ static uint8_t gb_battery_set_ship_mode(struct gb_operation *operation)
     }
 
     request = gb_operation_get_request_payload(operation);
+    if (request->mode != GB_BATTERY_SET_SHIP_MODE_READ) {
+        ret = device_battery_set_ship_mode(batt_dev, request->mode);
+    } else {
+        response = gb_operation_alloc_response(operation, sizeof(*response));
+        if (!response)
+            return GB_OP_NO_MEMORY;
 
-    ret = device_battery_set_ship_mode(batt_dev, request->mode);
+        ret = device_battery_get_ship_mode(batt_dev, &status);
+        response->status = status;
+    }
 
     return gb_errno_to_op_result(ret);
 }

--- a/nuttx/include/nuttx/device_battery.h
+++ b/nuttx/include/nuttx/device_battery.h
@@ -83,6 +83,9 @@ struct device_battery_type_ops {
 
     /** battery set_ship_mode() function pointer */
     int (*set_ship_mode)(struct device *dev, uint8_t mode);
+
+    /** battery get_ship_mode() function pointer */
+    int (*get_ship_mode)(struct device *dev, uint8_t *status);
 };
 
 /**
@@ -265,6 +268,7 @@ static inline int device_battery_shutdown_temp(struct device *dev,
 /**
  * @brief battery set ship mode
  * @param dev pointer to structure of device data.
+ * @param mode The requested mode to transition to
  * @return 0 on success, negative errno on error.
  */
 static inline int device_battery_set_ship_mode(struct device *dev, uint8_t mode)
@@ -277,6 +281,26 @@ static inline int device_battery_set_ship_mode(struct device *dev, uint8_t mode)
     if (DEVICE_DRIVER_GET_OPS(dev, battery)->set_ship_mode)
         return DEVICE_DRIVER_GET_OPS(dev, battery)->
                set_ship_mode(dev, mode);
+
+    return -ENOSYS;
+}
+
+/**
+ * @brief battery get ship mode
+ * @param dev pointer to structure of device data.
+ * @param status The ship mode status of the battery
+ * @return 0 on success, negative errno on error.
+ */
+static inline int device_battery_get_ship_mode(struct device *dev, uint8_t *status)
+{
+    DEVICE_DRIVER_ASSERT_OPS(dev);
+
+    if (!device_is_open(dev))
+        return -ENODEV;
+
+    if (DEVICE_DRIVER_GET_OPS(dev, battery)->get_ship_mode)
+        return DEVICE_DRIVER_GET_OPS(dev, battery)->
+               get_ship_mode(dev, status);
 
     return -ENOSYS;
 }


### PR DESCRIPTION
When the mode is read, return the Mod battery's ship mode state.
This is needed since not all Mods will power off (due to b+) when
entering ship mode.