### PR TITLE
build: Allow environment to override OVERRIDE_BUILD_NUM

### DIFF
--- a/nuttx/Makefile.unix
+++ b/nuttx/Makefile.unix
@@ -282,8 +282,11 @@ endif
 ifeq (${BUILD_NUMBER},)
   BUILD_NUMBER = 1
 endif
+
 OVERRIDE_VERSION = ${BUILD_MAJOR_NUMBER}.${BUILD_NUMBER}
-OVERRIDE_BUILD_NUM = ${shell git describe --always --dirty --match nothing 2>/dev/null}
+ifeq (${OVERRIDE_BUILD_NUM},)
+  OVERRIDE_BUILD_NUM = ${shell git describe --always --dirty --match nothing 2>/dev/null}
+endif
 
 $(TOPDIR)/.version: FORCE
 	tools/version.sh -v $(OVERRIDE_VERSION) -b $(OVERRIDE_BUILD_NUM) .version; \


### PR DESCRIPTION
Change-Id: Iadf0a241fa469525fc05a4ac03bb352e6d6c44d7
Signed-off-by: Jim Wylder <jwylder@motorola.com>